### PR TITLE
Use full class name for rvm_environment resource usage inside Chef::Provider::Package:RVMRubygems class

### DIFF
--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -126,10 +126,9 @@ class Chef
           # ensure each ruby is installed and gemset exists
           ruby_strings.each do |rubie|
             next if rubie == 'system'
-            e = rvm_environment rubie do
-              user    gem_env.user if gem_env.user
-              action :nothing
-            end
+            e = ::Chef::Resource::RvmEnvironment.new(rubie, @run_context)
+            e.user(gem_env.user) if gem_env.user
+            e.action(:nothing)
             e.run_action(:create)
           end
 


### PR DESCRIPTION
I propose this change because the cookbook was not working with Chef 12.0.0. I also tested it with previous versions and works as expected.

This should fix: https://github.com/fnichol/chef-rvm/issues/283.